### PR TITLE
enable livereload for CSS updates

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -69,7 +69,10 @@ module.exports = function( grunt ){
 		watch: {
 			styles: {
 				files: ['assets/styles/**/*.scss','assets/styles/**/*.css','assets/styles/**/*.sass'],
-				tasks: ['compilecss']
+				tasks: ['compilecss'],
+				options: {
+					livereload: true
+				}
 			},
 			templates: {
 				files: ['views/**/*.hbs'],

--- a/root/package.json
+++ b/root/package.json
@@ -5,12 +5,12 @@
     "solidus": "~0.0.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
+    "grunt": "~0.4.1",
     "grunt-contrib-sass": "~0.2.2",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-copy": "~0.4.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-handlebars": "~0.5.8",
-    "grunt-contrib-watch": "~0.3.1"
+    "grunt-contrib-watch": "~0.4.3"
   }
 }


### PR DESCRIPTION
I've just added the new livereload functionality in grunt-contrib-watch.
